### PR TITLE
AuthSettingsController 保存すると空の1行が余計に登録されるバグ対応

### DIFF
--- a/Controller/AuthSettingsController.php
+++ b/Controller/AuthSettingsController.php
@@ -109,6 +109,9 @@ class AuthSettingsController extends SystemManagerAppController {
 		// > コンポーネントを動的にロードした場合、初期化メソッドが実行されないことを覚えておいて下さい。 このメソッドで読込んだ場合、ロード後に手動で実行する必要があります。
 		$this->$pluginComponent->initialize($this);
 
+		// activeAuthTabを除去
+		$this->request->data = Hash::remove($this->request->data, 'SiteSetting.activeAuthTab');
+
 		// $this->AuthXXXXSetting->edit()
 		$this->$pluginComponent->edit();
 	}


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1111

トラビステスト通ったら、マージしようと思ってます。